### PR TITLE
Add RawMessage, like json.RawMessage, but implements proto.{Marshaler,Unmarshaler}.

### DIFF
--- a/rawmessage.go
+++ b/rawmessage.go
@@ -1,0 +1,36 @@
+package pbtypes
+
+import "errors"
+
+// RawMessage is a raw encoded JSON object.
+// It implements json.Marshaler and json.Unmarshaler like json.RawMessage,
+// but also proto.Marshaler and proto.Unmarshaler.
+type RawMessage []byte
+
+// MarshalJSON returns *m as the JSON encoding of m.
+func (m *RawMessage) MarshalJSON() ([]byte, error) {
+	return *m, nil
+}
+
+// UnmarshalJSON sets *m to a copy of data.
+func (m *RawMessage) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("pbtypes.RawMessage: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}
+
+// Marshal implements proto.Marshaler.
+func (m *RawMessage) Marshal() ([]byte, error) {
+	return *m, nil
+}
+
+// Unmarshal implements proto.Unmarshaler.
+func (m *RawMessage) Unmarshal(data []byte) error {
+	if m == nil {
+		return errors.New("pbtypes.RawMessage: Unmarshal on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}

--- a/rawmessage_test.go
+++ b/rawmessage_test.go
@@ -1,0 +1,14 @@
+package pbtypes_test
+
+import (
+	"encoding/json"
+
+	"github.com/gogo/protobuf/proto"
+	"sourcegraph.com/sqs/pbtypes"
+)
+
+var _ json.Marshaler = (*pbtypes.RawMessage)(nil)
+var _ json.Unmarshaler = (*pbtypes.RawMessage)(nil)
+
+var _ proto.Marshaler = (*pbtypes.RawMessage)(nil)
+var _ proto.Unmarshaler = (*pbtypes.RawMessage)(nil)


### PR DESCRIPTION
This is needed to fix a regression caused by https://github.com/sourcegraph/srclib/pull/177, since `json.RawMessage` (of `encoding/json`) does not implement `proto.Marshaler` and `proto.Unmarshaler`.
