### PR TITLE
Use consistent indentation for .proto files.

### DIFF
--- a/html.proto
+++ b/html.proto
@@ -8,5 +8,5 @@ import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 // that this value is sanitized HTML code, see
 // https://facebook.github.io/react/tips/dangerously-set-inner-html.html
 message HTML {
-  string HTML = 1 [(gogoproto.jsontag) = "__html"];
+	string HTML = 1 [(gogoproto.jsontag) = "__html"];
 }

--- a/timestamp.proto
+++ b/timestamp.proto
@@ -36,14 +36,14 @@ syntax = "proto3";
 package pbtypes;
 
 message Timestamp {
-  // Represents seconds of UTC time since Unix epoch
-  // 1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to
-  // 9999-12-31T23:59:59Z inclusive.
-  int64 seconds = 1;
+	// Represents seconds of UTC time since Unix epoch
+	// 1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to
+	// 9999-12-31T23:59:59Z inclusive.
+	int64 seconds = 1;
 
-  // Non-negative fractions of a second at nanosecond resolution. Negative
-  // second values with fractions must still have non-negative nanos values
-  // that count forward in time. Must be from 0 to 999,999,999
-  // inclusive.
-  int32 nanos = 2;
+	// Non-negative fractions of a second at nanosecond resolution. Negative
+	// second values with fractions must still have non-negative nanos values
+	// that count forward in time. Must be from 0 to 999,999,999
+	// inclusive.
+	int32 nanos = 2;
 }


### PR DESCRIPTION
In all other repositories, single tabs are used for indentation in .proto files.

/cc @neelance
