### PR TITLE
add go.mod and go.sum files for Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module sourcegraph.com/sqs/pbtypes
+
+require github.com/gogo/protobuf v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
+github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
PR adds go.mod and go.sum files for easier use of the package with Go modules.

Would you also please consider adding a semver tag such as `v1.0.0` (or `v.0.9.0` etc.), please?  It would make it easier for the library users to include it into their `go.mod`, it wouldn't need to be `sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4` or similar.  (I believe if you create a Release `v1.0.0` on https://github.com/sqs/pbtypes/releases, GitHub will automatically tag the code)